### PR TITLE
feat: add `drop` argument to deal with empty facet levels

### DIFF
--- a/R/facetwarp.R
+++ b/R/facetwarp.R
@@ -8,16 +8,7 @@
 #'   the plot. Using `strip.position` it is possible to place the labels on
 #'   either of the four sides by setting \code{strip.position = c("top",
 #'   "bottom", "left", "right")}
-#' @param labeller A function that takes one data frame of labels and
-#'   returns a list or data frame of character vectors. Each input
-#'   column corresponds to one factor. Thus there will be more than
-#'   one with `vars(cyl, am)`. Each output
-#'   column gets displayed as one separate line in the strip
-#'   label. This function should inherit from the "labeller" S3 class
-#'   for compatibility with [labeller()]. You can use different labeling
-#'   functions for different kind of labels, for example use [label_parsed()] for
-#'   formatting facet labels. [label_value()] is used by default,
-#'   check it for more details and pointers to other options.
+#' @inheritParams ggplot2::facet_wrap
 #' @examples
 #' ggplot(iris)+
 #'    geom_point(aes(x=Petal.Width, y=Petal.Length))+
@@ -28,7 +19,8 @@ facet_warp <- function(facets,
                        macro_x, macro_y,
                        nrow = NULL, ncol = NULL,
                        strip.position = "top",
-                       labeller = "label_value") {
+                       labeller = "label_value",
+                       drop = TRUE) {
   ggproto(NULL, FacetWarp,
           params = list(
             facets = rlang::quos_auto_name(facets),
@@ -37,7 +29,8 @@ facet_warp <- function(facets,
             strip.position = strip.position,
             labeller = labeller,
             ncol = ncol,
-            nrow = nrow
+            nrow = nrow,
+            drop = drop
           )
   )
 }
@@ -64,7 +57,7 @@ FacetWarp <- ggproto("FacetWarp", FacetWrap,
                          data = data,
                          env = params$plot_env,
                          vars = params$facets,
-                         drop = FALSE
+                         drop = drop
                        )
 
                        # autocompute n_rows and n_cols

--- a/R/facetwarp.R
+++ b/R/facetwarp.R
@@ -51,7 +51,7 @@ FacetWarp <- ggproto("FacetWarp", FacetWrap,
                          data = data,
                          env = params$plot_env,
                          vars = params$facets,
-                         drop = drop
+                         drop = params$drop
                        )
 
                        # autocompute n_rows and n_cols

--- a/R/facetwarp.R
+++ b/R/facetwarp.R
@@ -1,13 +1,7 @@
 #' Arrange Facets for your ggplot object
 #'
-#' @param facets A variable, quoted by vars(), defining faceting groups
 #' @param macro_x the name of a column which shall be used to arrange facets horizontally
 #' @param macro_y the name of a column which shall be used to arrange facets vertically
-#' @param nrow,ncol Number of rows and columns.
-#' @param strip.position By default, the labels are displayed on the top of
-#'   the plot. Using `strip.position` it is possible to place the labels on
-#'   either of the four sides by setting \code{strip.position = c("top",
-#'   "bottom", "left", "right")}
 #' @inheritParams ggplot2::facet_wrap
 #' @examples
 #' ggplot(iris)+

--- a/man/facet_warp.Rd
+++ b/man/facet_warp.Rd
@@ -16,7 +16,13 @@ facet_warp(
 )
 }
 \arguments{
-\item{facets}{A variable, quoted by vars(), defining faceting groups}
+\item{facets}{A set of variables or expressions quoted by \code{\link[ggplot2:vars]{vars()}}
+and defining faceting groups on the rows or columns dimension.
+The variables can be named (the names are passed to \code{labeller}).
+
+For compatibility with the classic interface, can also be a
+formula or character vector. Use either a one sided formula, \code{~a + b},
+or a character vector, \code{c("a", "b")}.}
 
 \item{macro_x}{the name of a column which shall be used to arrange facets horizontally}
 

--- a/man/facet_warp.Rd
+++ b/man/facet_warp.Rd
@@ -11,7 +11,8 @@ facet_warp(
   nrow = NULL,
   ncol = NULL,
   strip.position = "top",
-  labeller = "label_value"
+  labeller = "label_value",
+  drop = TRUE
 )
 }
 \arguments{
@@ -34,10 +35,14 @@ column corresponds to one factor. Thus there will be more than
 one with \code{vars(cyl, am)}. Each output
 column gets displayed as one separate line in the strip
 label. This function should inherit from the "labeller" S3 class
-for compatibility with \code{\link[=labeller]{labeller()}}. You can use different labeling
-functions for different kind of labels, for example use \code{\link[=label_parsed]{label_parsed()}} for
-formatting facet labels. \code{\link[=label_value]{label_value()}} is used by default,
+for compatibility with \code{\link[ggplot2:labeller]{labeller()}}. You can use different labeling
+functions for different kind of labels, for example use \code{\link[ggplot2:label_parsed]{label_parsed()}} for
+formatting facet labels. \code{\link[ggplot2:label_value]{label_value()}} is used by default,
 check it for more details and pointers to other options.}
+
+\item{drop}{If \code{TRUE}, the default, all factor levels not used in the
+data will automatically be dropped. If \code{FALSE}, all factor levels
+will be shown, regardless of whether or not they appear in the data.}
 }
 \description{
 Arrange Facets for your ggplot object


### PR DESCRIPTION
Fixes #6.

There was an issue w/ `facet_warp()` using `drop = FALSE`, which caused errors when there were missing facet args.

```r
# but what if we have a factor level not represented in the data?
bad_data <- filter(iris, Species != "setosa")

unique(bad_data$Species)
#> [1] versicolor virginica 
#> Levels: setosa versicolor virginica

ggplot(bad_data) +
  geom_point(aes(x = Petal.Width, y = Petal.Length)) +
  facet_warp(
    vars(Species),
    macro_x = 'Sepal.Width',
    macro_y = 'Sepal.Length',
    nrow = 3,
    ncol = 3
  )
#> Error in data.frame(PANEL = 1:nrow(panels), ROW = locations$ROW, COL = locations$COL, : arguments imply differing number of rows: 3, 2, 1
```

This PR fixes the issue by adding an explicit `drop` arg to `facet_warp()`, defaulting to `TRUE`. At the mo, `drop = FALSE` does error, but there may be potential in the future to handle that in some way, or perhaps users will want the function to error (e.g., to catch missing factor levels caused by an upstream issue).

`drop` documentation inherits from `ggplot2::facet_wrap()`.