### PR TITLE
fix: ensure `facet_warp()` works with its default args w/ under 4 facet levels

### DIFF
--- a/R/facetwarp.R
+++ b/R/facetwarp.R
@@ -70,14 +70,26 @@ FacetWarp <- ggproto("FacetWarp", FacetWrap,
                        # autocompute n_rows and n_cols
                        dims <- ggplot2::wrap_dims(nrow(panels), params$nrow, params$ncol)
 
-                       # core lap algorithm
-                       locations <- compute_arrangement(mydata = data,
-                                                        macro_x = params$macro_x,
-                                                        macro_y = params$macro_y,
-                                                        faceter = gsub('~','',as.character(params$facets)),
-                                                        n_row = dims[1],
-                                                        n_col = dims[2])
+                       # special case - only one factor level
+                       if (all(dims == 1L)) {
+                         locations <- data.frame(facet_id = 1,
+                                                 ROW = 1,
+                                                 COL = 1)
+                       } else {
+                         # ensure 2x2 grid minimum
+                         if (all(sort(dims) == c(1, 2) | all(sort(dims) == c(1, 3)))) {
+                           dims <- c(2, 2)
+                         }
 
+                         # core lap algorithm
+                         locations <- compute_arrangement(mydata = data,
+                                                          macro_x = params$macro_x,
+                                                          macro_y = params$macro_y,
+                                                          faceter = gsub('~','',as.character(params$facets)),
+                                                          n_row = dims[1],
+                                                          n_col = dims[2])
+                       }
+                       
                        # Assign each panel a location
                        layout <- data.frame(
                          PANEL = 1:nrow(panels), # panel identifier


### PR DESCRIPTION
Hi Matt, thought I'd have a go at sorting #8.

There is an issue relating to `ggplot2::wrap_dims()` creating 1x1/2/3 grids when there aren't many factor levels. This causes the grid computation to totally fall down.

This PR aims to fix this by adding hard-coded exceptions for 1x1, 1x2 and 1x3 `dims`.
* 1x1 returns a single panel.
* 1x2 and 1x3 are both transformed into 2x2 grids.

Users can still specify `nrow`/`ncol`, of course; this just ensures the default `NULL` args won't fail with small datasets (e.g., `iris` or `penguins`, which many users may demo `facet_warp()` with!)

Demo of behaviour:

``` r
devtools::load_all()
#> ℹ Loading facetwarp
library(ggplot2)

prep_data <- function(f) {
  tidyr::expand_grid(
    x = 1:5,
    y = 1:5,
    f = factor(f)
  ) %>%
    dplyr::mutate(x = jitter(x), y = jitter(y))
}

prep_data(c("a")) %>%
  ggplot() + facet_warp(vars(f), "x", "y")
```

![](https://i.imgur.com/DJnoYZF.png)<!-- -->

``` r

prep_data(c("a", NA)) %>%
  ggplot() + facet_warp(vars(f), "x", "y")
```

![](https://i.imgur.com/QJfwath.png)<!-- -->

``` r

prep_data(c("a", "b", "c")) %>%
  ggplot() + facet_warp(vars(f), "x", "y")
```

![](https://i.imgur.com/xltWh04.png)<!-- -->

``` r

prep_data(c("a", "b", "c", "d", "e")) %>%
  ggplot() + 
  facet_warp(vars(f), "x", "y")
```

![](https://i.imgur.com/ycDdXKn.png)<!-- -->

<sup>Created on 2023-10-15 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
