### PR TITLE
fix: R CMD errors and warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ RoxygenNote: 7.2.3
 Imports:
     dplyr,
     ggplot2,
-    lpSolve
+    lpSolve,
+    rlang
 Suggests: 
     knitr,
     rmarkdown

--- a/R/arrange.R
+++ b/R/arrange.R
@@ -4,12 +4,11 @@
 #' @param macro_x the name of a column which shall be used to arrange facets horizontally
 #' @param macro_y the name of a column which shall be used to arrange facets vertically
 #' @param faceter the column name defining faceting groups
-#' @param nrow,ncol Number of rows and columns.
+#' @param n_row,n_col Number of rows and columns.
 #' @import dplyr
 #' @import lpSolve
 compute_arrangement <- function(mydata, macro_x, macro_y, faceter, n_row, n_col){
 
-  library(lpSolve)
   dt <- as.data.frame(mydata)
 
   ##############################################################################

--- a/R/facetwarp.R
+++ b/R/facetwarp.R
@@ -19,6 +19,7 @@
 #'   formatting facet labels. [label_value()] is used by default,
 #'   check it for more details and pointers to other options.
 #' @examples
+#' library(ggplot2)
 #' ggplot(iris)+
 #'    geom_point(aes(x=Petal.Width, y=Petal.Length))+
 #'    facet_warp(vars(Species), macro_x='Sepal.Width', macro_y='Sepal.Length', nrow = 2)

--- a/man/compute_arrangement.Rd
+++ b/man/compute_arrangement.Rd
@@ -15,7 +15,7 @@ compute_arrangement(mydata, macro_x, macro_y, faceter, n_row, n_col)
 
 \item{faceter}{the column name defining faceting groups}
 
-\item{nrow, ncol}{Number of rows and columns.}
+\item{n_row, n_col}{Number of rows and columns.}
 }
 \description{
 Compute Arrangement Using Jonker & Volgenant algorithm

--- a/man/facet_warp.Rd
+++ b/man/facet_warp.Rd
@@ -43,6 +43,7 @@ check it for more details and pointers to other options.}
 Arrange Facets for your ggplot object
 }
 \examples{
+library(ggplot2)
 ggplot(iris)+
    geom_point(aes(x=Petal.Width, y=Petal.Length))+
    facet_warp(vars(Species), macro_x='Sepal.Width', macro_y='Sepal.Length', nrow = 2)


### PR DESCRIPTION
As I was looking at other bits and bobs (#9 and #10), I noted a few errors and warnings when running `devtools::check()`:

```r
── R CMD check results ─────────────────────────────────────────────────────────────────────────────── facetwarp 0.0.1 ────
Duration: 45.1s

❯ checking examples ... ERROR
  Running examples in 'facetwarp-Ex.R' failed
  The error most likely occurred in:
  
  > base::assign(".ptime", proc.time(), pos = "CheckExEnv")
  > ### Name: facet_warp
  > ### Title: Arrange Facets for your ggplot object
  > ### Aliases: facet_warp
  > 
  > ### ** Examples
  > 
  > ggplot(iris)+
  +    geom_point(aes(x=Petal.Width, y=Petal.Length))+
  +    facet_warp(vars(Species), macro_x='Sepal.Width', macro_y='Sepal.Length', nrow = 2)
  Error in ggplot(iris) : could not find function "ggplot"
  Execution halted

❯ checking dependencies in R code ... WARNING
  '::' or ':::' import not declared from: 'rlang'
  'library' or 'require' call not declared from: 'lpSolve'
  'library' or 'require' call to 'lpSolve' in package code.
    Please use :: or requireNamespace() instead.
    See section 'Suggested packages' in the 'Writing R Extensions' manual.

❯ checking Rd \usage sections ... WARNING
  Undocumented arguments in documentation object 'compute_arrangement'
    'n_row' 'n_col'
  Documented arguments not in \usage in documentation object 'compute_arrangement':
    'nrow' 'ncol'
  
  Functions with \usage entries need to have the appropriate \alias
  entries, and all their arguments documented.
  The \usage entries must correspond to syntactically valid R code.
  See chapter 'Writing R documentation files' in the 'Writing R
  Extensions' manual.
```

This PR fixes these few little issues:

* Adds `{rlang}` to the imports.
* Adds a library call to `{ggplot2}` in the `facet_warp()` example.
* Removes the `library()` call within a function.
* Fixes names in `compute_arrangement()` documentation (if this is meant to be exported!)

NB: there are still some NOTES:

```r
── R CMD check results ─────────────────────────────────────────────────────────────────────────────── facetwarp 0.0.1 ────
Duration: 42.6s

❯ checking R code for possible problems ... NOTE
  compute_arrangement: no visible global function definition for 'median'
  compute_arrangement: no visible binding for global variable 'x'
  compute_arrangement: no visible binding for global variable 'y'
  compute_arrangement: no visible binding for global variable 'COL'
  compute_arrangement: no visible binding for global variable 'ROW'
  compute_arrangement: no visible binding for global variable 'x_min'
  compute_arrangement: no visible binding for global variable 'x_max'
  compute_arrangement: no visible binding for global variable 'y_min'
  compute_arrangement: no visible binding for global variable 'y_max'
  compute_arrangement: no visible binding for global variable 'facet_id'
  Undefined global functions or variables:
    COL ROW facet_id median x x_max x_min y y_max y_min
  Consider adding
    importFrom("stats", "median")
  to your NAMESPACE file.
```